### PR TITLE
Save share files to app images directory

### DIFF
--- a/android/src/main/java/cl/json/ShareFile.java
+++ b/android/src/main/java/cl/json/ShareFile.java
@@ -123,7 +123,7 @@ public class ShareFile {
         if(this.isBase64File()) {
             String encodedImg = this.uri.getSchemeSpecificPart().substring(this.uri.getSchemeSpecificPart().indexOf(";base64,") + 8);
             try {
-                File dir = new File(Environment.getExternalStorageDirectory(), Environment.DIRECTORY_DOWNLOADS );
+                File dir = new File(this.reactContext.getFilesDir(), "images");
                 if (!dir.exists()) {
                     dir.mkdirs();
                 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "react-native-share",
   "description": "Social Share, Sending Simple Data to Other Apps",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/EstebanFuentealba/react-native-share.git"
+    "url": "git+https://github.com/mojotech/react-native-share.git"
   },
   "keywords": [
     "react-component",


### PR DESCRIPTION
This saves files to be share in an `images` directory that is within the app. This alleviates some file permissions issues.

When implementing in a React Native app, It requires provider and meta data tags to be included in the `AndroidManifest.xml` file under `application` like this example:

```
<application ...
        <provider
          android:name="android.support.v4.content.FileProvider"
          android:authorities="com.amicamobile${APP_ID_SUFFIX}.provider"
          android:grantUriPermissions="true"
          android:exported="false">
          <meta-data
            android:name="android.support.FILE_PROVIDER_PATHS"
            android:resource="@xml/filepaths" />
        </provider>
...
</application>
```
And a new `filepaths.xml` file under `android/app/src/main/res/xml` containing:

```
<paths>
    <files-path path="images/" name="myimages" />
</paths>

```

 